### PR TITLE
Allow for passing attributes to LiveAnnouncer

### DIFF
--- a/src/modules/Announcer.js
+++ b/src/modules/Announcer.js
@@ -66,13 +66,20 @@ class Announcer extends Component {
 
   render() {
     const {
+      politeMessage,
+      politeMessageId,
+      assertiveMessage,
+      assertiveMessageId,
+      ...rest,
+    } = this.props;
+    const {
       assertiveMessage1,
       assertiveMessage2,
       politeMessage1,
       politeMessage2,
     } = this.state;
     return (
-      <div>
+      <div {...rest}>
         <MessageBlock aria-live="assertive" message={assertiveMessage1} />
         <MessageBlock aria-live="assertive" message={assertiveMessage2} />
         <MessageBlock aria-live="polite" message={politeMessage1} />

--- a/src/modules/__tests__/Announcer.spec.js
+++ b/src/modules/__tests__/Announcer.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { mount } from 'enzyme';
-import { mountToJson } from 'enzyme-to-json';
+import { mount, shallow } from 'enzyme';
+import { mountToJson, shallowToJson } from 'enzyme-to-json';
 import Announcer from '../Announcer';
 
 describe('Announcer', () => {
@@ -67,5 +67,18 @@ describe('Announcer', () => {
     expect(wrapper.find('MessageBlock').get(3).props.message).toEqual(
       'I am a changed message'
     );
+  });
+
+  it('should set props', () => {
+    const wrapper = shallow(
+      <Announcer
+        assertiveMessage=""
+        politeMessage="I am a message"
+        id="my-announcer"
+      />
+    );
+
+    const tree = shallowToJson(wrapper);
+    expect(tree).toMatchSnapshot();
   });
 });

--- a/src/modules/__tests__/__snapshots__/Announcer.spec.js.snap
+++ b/src/modules/__tests__/__snapshots__/Announcer.spec.js.snap
@@ -93,3 +93,26 @@ exports[`Announcer should render correctly via snapshot 1`] = `
   </div>
 </Announcer>
 `;
+
+exports[`Announcer should set props 1`] = `
+<div
+  id="my-announcer"
+>
+  <MessageBlock
+    aria-live="assertive"
+    message=""
+  />
+  <MessageBlock
+    aria-live="assertive"
+    message=""
+  />
+  <MessageBlock
+    aria-live="polite"
+    message="I am a message"
+  />
+  <MessageBlock
+    aria-live="polite"
+    message=""
+  />
+</div>
+`;


### PR DESCRIPTION
Hi,

Thanks for the awesome library and the amazing blog post behind it!

I'm running in a situation where (and you may know a better way to do this but currently) in some instances where a modal (or some sort of overlay) that acts as a foreground, we want to ensure that we don't continue to send messages to screenreaders for background activities (behind the modal/overlay). This can be done by having 2 `LiveAnnouncer` where each maintains their own set of messages and passing `aria-hidden` to either instance based on the circumstances.

To do so, this PR will allow users to pass attributes to the root div container that is rendered by `LiveAnnouncer`.

Open for suggestions and alternative recommendations if any.
